### PR TITLE
Fix: Naming blueprint in readme as in yaml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The "Holidays" mode on my TRV is not yet used, but will probably be to say "The 
 
 ## Blueprints
 
-### Heater system management global script
+### Heating system should start
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Ffrancois09%2FHA_BP_heating%2Fblob%2Fmain%2Fheater_one_need.yaml)
 
@@ -93,31 +93,31 @@ for rooms links to determine if heating system should be shutdown.
 
 This blueprint is used at HA boot, to avoid receiving climate valve messages for a certain time. Sometimes, setpoint is received just after the boot, turning climate to be interpreted as a manual selection.
 
-### Heater request compute
+### Room heating request compute
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Ffrancois09%2FHA_BP_heating%2Fblob%2Fmain%2Fheater_request_compute.yaml)
 
 This blueprint compute the boolean (switch) helper of the room, based on Climate valve setpoint, and room T°. If heating is requested, it aslo fake the local_temperature_calibration to ensure valve is correctly opened. In my case, T° sensor is far from Climate, and close to my preffered location in the room.
 
-### Heater setpoint compute
+### Room heating setpoint compute
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Ffrancois09%2FHA_BP_heating%2Fblob%2Fmain%2Fheater_setpoint_compute.yaml)
 
 This blueprint compute the correct setpoint based on the room schedule and the potential manual setting, to determine and send it to the Climate valve.
 
-### Heater switch mode
+### Room heating mode switching
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Ffrancois09%2FHA_BP_heating%2Fblob%2Fmain%2Fheater_switch_mode.yaml)
 
 This blueprint take into account a manual change on the Climate valve, or the Auto setting to modify setpoint.
 
-### Heater room link management
+### Room link status
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Ffrancois09%2FHA_BP_heating%2Fblob%2Fmain%2Fheater_room_link.yaml)
 
 This blueprint use the doors/windows status to determine if a room is linked to Inside/Outside/Both/None. When linked Outside, it stop and lock climate valve. It also setup a link helper to decide if we have to shutdown heating system or not.
 
-### Heater Winter mode management
+### Heating system operationnal or not
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Ffrancois09%2FHA_BP_heating%2Fblob%2Fmain%2Fheater_start_stop.yaml)
 


### PR DESCRIPTION
Name should be the same to avoid confusions